### PR TITLE
Make queue name in url configurable

### DIFF
--- a/config/mount/sample.ini
+++ b/config/mount/sample.ini
@@ -3,7 +3,7 @@ enqueue_job_base_url = http://actinia-core:8088/api/v3
 use_actinia_modules = True
 user = actinia-gdi
 password = actinia-gdi
-worker_http_launcher_url = http://actinia-worker-http-launcher:8000/launch
+worker_http_launcher_url = http://actinia-worker-http-launcher:8000/launch/{{ queue_name }}
 
 [EVENTRECEIVER]
 url = http://event-receiver-server:3000/

--- a/src/actinia_cloudevent_plugin/api/cloudevents.py
+++ b/src/actinia_cloudevent_plugin/api/cloudevents.py
@@ -71,7 +71,9 @@ class Cloudevent(Resource):
                 # job is processed directly.
                 log.info("No need to start actinia-worker")
             else:
-                url = f"{ACTINIA.worker_http_launcher_url}/{queue_name}"
+                url = ACTINIA.worker_http_launcher_url
+                if "{{ queue_name }}" in url:
+                    url.replace("{{ queue_name }}", queue_name)
                 new_event = send_binary_cloud_event(
                     event_received,
                     queue_name,


### PR DESCRIPTION
To be able to have the job queue as a variable in the path of `ACTINIA.worker_http_launcher_url`, with this PR it can be configured to include it or not.